### PR TITLE
election: generate random election timeout and convert to follower if newer term is acpuired

### DIFF
--- a/src/raft/vote.rs
+++ b/src/raft/vote.rs
@@ -47,6 +47,7 @@ impl<D: AppData, R: AppDataResponse, E: AppError, N: RaftNetwork<D>, S: RaftStor
         if &msg.term > &self.current_term {
             self.update_current_term(msg.term, None);
             self.save_hard_state(ctx);
+            self.become_follower(ctx);
         }
 
         // Check if candidate's log is at least as up-to-date as this node's.
@@ -68,7 +69,7 @@ impl<D: AppData, R: AppDataResponse, E: AppError, N: RaftNetwork<D>, S: RaftStor
             None => {
                 self.voted_for = Some(msg.candidate_id);
                 self.save_hard_state(ctx);
-                self.update_election_timeout_stamp();
+                self.update_election_timeout(ctx);
                 self.become_follower(ctx);
                 Ok(VoteResponse{term: self.current_term, vote_granted: true, is_candidate_unknown: false})
             },


### PR DESCRIPTION
Signed-off-by: Iosmanthus Teng <myosmanthustree@gmail.com>

I found a critical bug while building a 2-node cluster for my POC. Here is a reproduction of it (more unit tests and integration tests are needed to cover these cases).

1. Initialize each node in the 2-node cluster; each node is running in an independent process.
2. Send some client requests to the leader.
3. Suspend the follower process.
4. Send more client requests to the leader. The leader hangs as expected.
5. Wait for a while, about 5 - 10s, wake up the follower with `fg`.
6. The follower exceeds the election timeout deadline, converts to the candidate state and emit a new election with a term `== leader.term + 1`
7. The new candidate sends `RequestVote` indefinitely.
8. The old leader won't convert to a follower while it encounters a newer term.

I try to convert the leader to the follower state while meets a newer term in `VoteRequest`, however, they always convert to the candidate states 'simultaneously'... So I add a random election timeout for the candidate state according to the Raft spec.