### PR TITLE
NodeNotLeader returns current leader id

### DIFF
--- a/async-raft/src/core/mod.rs
+++ b/async-raft/src/core/mod.rs
@@ -353,7 +353,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
     /// Reject a proposed config change request due to the Raft node being in a state which prohibits the request.
     #[tracing::instrument(level="trace", skip(self, tx))]
     fn reject_config_change_not_leader(&self, tx: oneshot::Sender<Result<(), ChangeConfigError>>) {
-        let _ = tx.send(Err(ChangeConfigError::NodeNotLeader));
+        let _ = tx.send(Err(ChangeConfigError::NodeNotLeader(self.current_leader)));
     }
 
     /// Forward the given client write request to the leader.

--- a/async-raft/src/error.rs
+++ b/async-raft/src/error.rs
@@ -94,9 +94,10 @@ pub enum ChangeConfigError {
     /// the cluster in an inoperable state.
     #[error("the given config would leave the cluster in an inoperable state")]
     InoperableConfig,
-    /// The node the config change proposal was sent to was not the leader of the cluster.
+    /// The node the config change proposal was sent to was not the leader of the cluster. The id
+    /// of the current leader is returned.
     #[error("this node is not the Raft leader")]
-    NodeNotLeader,
+    NodeNotLeader(Option<NodeId>),
     /// The proposed config changes would make no difference to the current config.
     ///
     /// This takes into account a current joint consensus and the end result of the config.
@@ -108,7 +109,7 @@ impl<D: AppData> From<ClientWriteError<D>> for ChangeConfigError {
     fn from(src: ClientWriteError<D>) -> Self {
         match src {
             ClientWriteError::RaftError(err) => Self::RaftError(err),
-            ClientWriteError::ForwardToLeader(_, _) => Self::NodeNotLeader,
+            ClientWriteError::ForwardToLeader(_, id) => Self::NodeNotLeader(id),
         }
     }
 }


### PR DESCRIPTION
It is useful to return the leader id when a node return a NotLeaderId error, so request can be forwarded to the leader.