### PR TITLE
Add parallel writes test.

### DIFF
--- a/async-raft/tests/client_writes.rs
+++ b/async-raft/tests/client_writes.rs
@@ -73,3 +73,47 @@ async fn client_writes() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(core_threads = 4)]
+async fn parallel_client_writes() -> Result<()> {
+    fixtures::init_tracing();
+
+    // Setup test dependencies.
+    let config = Arc::new(Config::build("test".into()).validate().expect("failed to build Raft config"));
+    let router = Arc::new(RaftRouter::new(config.clone()));
+    router.new_raft_node(0).await;
+    router.new_raft_node(1).await;
+    router.new_raft_node(2).await;
+
+    // Assert all nodes are in non-voter state & have no entries.
+    delay_for(Duration::from_secs(10)).await;
+    router.assert_pristine_cluster().await;
+
+    // Initialize the cluster, then assert that a stable cluster was formed & held.
+    tracing::info!("--- initializing cluster");
+    router.initialize_from_single_node(0).await?;
+    delay_for(Duration::from_secs(10)).await;
+    router.assert_stable_cluster(Some(1), Some(1)).await;
+
+    // Write a bunch of data and assert that the cluster stayes stable.
+    let leader = router.leader().await.expect("leader not found");
+    let mut clients = futures::stream::FuturesUnordered::new();
+
+    for _ in 0..32 {
+        let router = router.clone();
+        clients.push(tokio::spawn(async move {
+            router.client_request_many(leader, "0", 1000).await;
+            router.client_request_many(leader, "1", 1000).await;
+            router.client_request_many(leader, "2", 1000).await;
+            router.client_request_many(leader, "3", 1000).await;
+            router.client_request_many(leader, "4", 1000).await;
+            router.client_request_many(leader, "5", 1000).await;
+        }))
+    }
+
+    while clients.next().await.is_some() {}
+    delay_for(Duration::from_secs(5)).await; // Ensure enough time is given for replication (this is WAY more than enough).
+    router.assert_stable_cluster(Some(1), Some(192001)).await; // The extra 1 is from the leader's initial commit entry.
+
+    Ok(())
+}


### PR DESCRIPTION
Hey, I am here again. 🙂

I found a small problem. When I call `client_write` in parallel, it will block and keep outputting the following log.

```
ERROR async_raft::replication: timeout while sending AppendEntries RPC to target error=deadline has elapsed
ERROR async_raft::replication: timeout while sending AppendEntries RPC to target error=deadline has elapsed
ERROR async_raft::replication: timeout while sending AppendEntries RPC to target error=deadline has elapsed
ERROR async_raft::replication: timeout while sending AppendEntries RPC to target error=deadline has elapsed
ERROR async_raft::replication: timeout while sending AppendEntries RPC to target error=deadline has elapsed
```

So I opened this PR to reproduce the problem.