### PR TITLE
Make the Raft handle clonable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This changelog follows the patterns described here: https://keepachangelog.com/e
 
 ## [unreleased]
 
+## async-raft 0.6.0-alpha.1
+### changed
+- The `Raft` type can now be cloned. The clone is very cheap and helps to facilitate async workflows while feeding client requests and Raft RPCs into the Raft instance.
+- The `Raft.shutdown` interface has been changed slightly. Instead of returning a `JoinHandle`, the method is now async and simply returns a result.
+- The `ClientWriteError::ForwardToLeader` error variant has been modified slightly. It now exposes the data (generic type `D` of the type) of the original client request directly. This ensures that the data can actually be used for forwarding, if that is what the parent app wants to do.
+
 ## memstore 0.2.0-alpha.0
 ### changed
 - Updated async-raft dependency to `0.6.0-aplpha.0` & updated storage interface as needed.

--- a/async-raft/Cargo.toml
+++ b/async-raft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-raft"
-version = "0.6.0-alpha.0"
+version = "0.6.0-alpha.1"
 edition = "2018"
 authors = ["Anthony Dodd <Dodd.AnthonyJosiah@gmail.com>"]
 categories = ["algorithms", "asynchronous", "data-structures"]

--- a/async-raft/src/error.rs
+++ b/async-raft/src/error.rs
@@ -2,7 +2,6 @@
 
 use thiserror::Error;
 
-use crate::raft::ClientWriteRequest;
 use crate::{AppData, NodeId};
 
 /// A result type where the error variant is always a `RaftError`.
@@ -48,7 +47,7 @@ pub enum ClientWriteError<D: AppData> {
     RaftError(#[from] RaftError),
     /// The client write request must be forwarded to the cluster leader.
     #[error("the client write request must be forwarded to the cluster leader")]
-    ForwardToLeader(ClientWriteRequest<D>, Option<NodeId>),
+    ForwardToLeader(D, Option<NodeId>),
 }
 
 /// Error variants related to configuration.

--- a/async-raft/src/raft.rs
+++ b/async-raft/src/raft.rs
@@ -34,6 +34,10 @@ struct RaftInner<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStora
 /// For details and discussion on this API, see the
 /// [Raft API](https://async-raft.github.io/async-raft/raft.html) section of the guide.
 ///
+/// ### clone
+/// This type implements `Clone`, and should be cloned liberally. The clone itself is very cheap
+/// and helps to facilitate use with async workflows.
+///
 /// ### shutting down
 /// If any of the interfaces returns a `RaftError::ShuttingDown`, this indicates that the Raft node
 /// is shutting down (potentially for data safety reasons due to a storage error), and the `shutdown`

--- a/async-raft/tests/shutdown.rs
+++ b/async-raft/tests/shutdown.rs
@@ -41,11 +41,11 @@ async fn initialization() -> Result<()> {
 
     tracing::info!("--- performing node shutdowns");
     let (node0, _) = router.remove_node(0).await.ok_or_else(|| anyhow!("failed to find node 0 in router"))?;
-    node0.shutdown().await??;
+    node0.shutdown().await?;
     let (node1, _) = router.remove_node(1).await.ok_or_else(|| anyhow!("failed to find node 1 in router"))?;
-    node1.shutdown().await??;
+    node1.shutdown().await?;
     let (node2, _) = router.remove_node(2).await.ok_or_else(|| anyhow!("failed to find node 2 in router"))?;
-    node2.shutdown().await??;
+    node2.shutdown().await?;
 
     Ok(())
 }


### PR DESCRIPTION
This is especially needed for cases where interaction with Raft from the
parent app needs to spawn a task for interacting with Raft. This makes
the interface a bit more flexible overall.

- [x] update changelog
- [x] update docs
- [x] update version & cut alpha.1