### PR TITLE
Improve ergonomics of client write error handling.

### DIFF
--- a/async-raft/src/core/append_entries.rs
+++ b/async-raft/src/core/append_entries.rs
@@ -1,9 +1,9 @@
 use crate::core::{RaftCore, State, UpdateCurrentLeader};
 use crate::error::RaftResult;
 use crate::raft::{AppendEntriesRequest, AppendEntriesResponse, ConflictOpt, Entry, EntryPayload};
-use crate::{AppData, AppDataResponse, RaftNetwork, RaftStorage};
+use crate::{AppData, AppDataResponse, AppError, RaftNetwork, RaftStorage};
 
-impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> RaftCore<D, R, N, S> {
+impl<D: AppData, E: AppError, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, E, R>> RaftCore<D, E, R, N, S> {
     /// An RPC invoked by the leader to replicate log entries (§5.3); also used as heartbeat (§5.2).
     ///
     /// See `receiver implementation: AppendEntries RPC` in raft-essentials.md in this repo.

--- a/async-raft/src/core/install_snapshot.rs
+++ b/async-raft/src/core/install_snapshot.rs
@@ -5,9 +5,9 @@ use tokio::io::{AsyncSeekExt, AsyncWriteExt};
 use crate::core::{RaftCore, SnapshotState, State, UpdateCurrentLeader};
 use crate::error::RaftResult;
 use crate::raft::{InstallSnapshotRequest, InstallSnapshotResponse};
-use crate::{AppData, AppDataResponse, RaftNetwork, RaftStorage};
+use crate::{AppData, AppDataResponse, AppError, RaftNetwork, RaftStorage};
 
-impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> RaftCore<D, R, N, S> {
+impl<D: AppData, E: AppError, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, E, R>> RaftCore<D, E, R, N, S> {
     /// Invoked by leader to send chunks of a snapshot to a follower (§7).
     ///
     /// Leaders always send chunks in order. It is important to note that, according to the Raft spec,

--- a/async-raft/src/core/replication.rs
+++ b/async-raft/src/core/replication.rs
@@ -5,9 +5,9 @@ use crate::core::{ConsensusState, LeaderState, ReplicationState, SnapshotState, 
 use crate::error::RaftResult;
 use crate::replication::{RaftEvent, ReplicaEvent, ReplicationStream};
 use crate::storage::CurrentSnapshotData;
-use crate::{AppData, AppDataResponse, NodeId, RaftNetwork, RaftStorage};
+use crate::{AppData, AppDataResponse, AppError, NodeId, RaftNetwork, RaftStorage};
 
-impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> LeaderState<'a, D, R, N, S> {
+impl<'a, D: AppData, E: AppError, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, E, R>> LeaderState<'a, D, E, R, N, S> {
     /// Spawn a new replication stream returning its replication state handle.
     #[tracing::instrument(level = "trace", skip(self))]
     pub(super) fn spawn_replication_stream(&self, target: NodeId) -> ReplicationState<D> {

--- a/async-raft/src/core/vote.rs
+++ b/async-raft/src/core/vote.rs
@@ -5,9 +5,9 @@ use tracing_futures::Instrument;
 use crate::core::{CandidateState, RaftCore, State, UpdateCurrentLeader};
 use crate::error::RaftResult;
 use crate::raft::{VoteRequest, VoteResponse};
-use crate::{AppData, AppDataResponse, NodeId, RaftNetwork, RaftStorage};
+use crate::{AppData, AppDataResponse, AppError, NodeId, RaftNetwork, RaftStorage};
 
-impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> RaftCore<D, R, N, S> {
+impl<D: AppData, E: AppError, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, E, R>> RaftCore<D, E, R, N, S> {
     /// An RPC invoked by candidates to gather votes (§5.2).
     ///
     /// See `receiver implementation: RequestVote RPC` in raft-essentials.md in this repo.
@@ -90,7 +90,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
     }
 }
 
-impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> CandidateState<'a, D, R, N, S> {
+impl<'a, D: AppData, E: AppError, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, E, R>> CandidateState<'a, D, E, R, N, S> {
     /// Handle response from a vote request sent to a peer.
     #[tracing::instrument(level = "trace", skip(self, res, target))]
     pub(super) async fn handle_vote_response(&mut self, res: VoteResponse, target: NodeId) -> RaftResult<()> {

--- a/async-raft/src/storage.rs
+++ b/async-raft/src/storage.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncSeek, AsyncWrite};
 
 use crate::raft::{Entry, MembershipConfig};
-use crate::{AppData, AppDataResponse, NodeId};
+use crate::{AppData, AppDataResponse, AppError, NodeId};
 
 /// The data associated with the current snapshot.
 pub struct CurrentSnapshotData<S>
@@ -75,9 +75,10 @@ impl InitialState {
 /// See the [storage chapter of the guide](https://async-raft.github.io/async-raft/storage.html)
 /// for details and discussion on this trait and how to implement it.
 #[async_trait]
-pub trait RaftStorage<D, R>: Send + Sync + 'static
+pub trait RaftStorage<D, E, R>: Send + Sync + 'static
 where
     D: AppData,
+    E: AppError,
     R: AppDataResponse,
 {
     /// The storage engine's associated type used for exposing a snapshot for reading & writing.
@@ -94,6 +95,8 @@ where
     /// If the system is pristine, then it should return the value of calling
     /// `MembershipConfig::new_initial(node_id)`. It is required that the storage engine persist
     /// the node's ID so that it is consistent across restarts.
+    ///
+    /// Errors returned from this method will cause Raft to go into shutdown.
     async fn get_membership_config(&self) -> Result<MembershipConfig>;
 
     /// Get Raft's state information from storage.
@@ -102,31 +105,42 @@ where
     /// fetch the last known state from stable storage. If no such entry exists due to being the
     /// first time the node has come online, then `InitialState::new_initial` should be used.
     ///
-    /// ### pro tip
-    /// The storage impl may need to look in a few different places to accurately respond to this
-    /// request: the last entry in the log for `last_log_index` & `last_log_term`; the node's hard
-    /// state record; and the index of the last log applied to the state machine.
+    /// **Pro tip:** the storage impl may need to look in a few different places to accurately
+    /// respond to this request: the last entry in the log for `last_log_index` & `last_log_term`;
+    /// the node's hard state record; and the index of the last log applied to the state machine.
+    ///
+    /// Errors returned from this method will cause Raft to go into shutdown.
     async fn get_initial_state(&self) -> Result<InitialState>;
 
     /// Save Raft's hard-state.
+    ///
+    /// Errors returned from this method will cause Raft to go into shutdown.
     async fn save_hard_state(&self, hs: &HardState) -> Result<()>;
 
     /// Get a series of log entries from storage.
     ///
     /// The start value is inclusive in the search and the stop value is non-inclusive: `[start, stop)`.
+    ///
+    /// Errors returned from this method will cause Raft to go into shutdown.
     async fn get_log_entries(&self, start: u64, stop: u64) -> Result<Vec<Entry<D>>>;
 
     /// Delete all logs starting from `start` and stopping at `stop`, else continuing to the end
     /// of the log if `stop` is `None`.
+    ///
+    /// Errors returned from this method will cause Raft to go into shutdown.
     async fn delete_logs_from(&self, start: u64, stop: Option<u64>) -> Result<()>;
 
     /// Append a new entry to the log.
+    ///
+    /// Errors returned from this method will cause Raft to go into shutdown.
     async fn append_entry_to_log(&self, entry: &Entry<D>) -> Result<()>;
 
     /// Replicate a payload of entries to the log.
     ///
     /// Though the entries will always be presented in order, each entry's index should be used to
     /// determine its location to be written in the log.
+    ///
+    /// Errors returned from this method will cause Raft to go into shutdown.
     async fn replicate_to_log(&self, entries: &[Entry<D>]) -> Result<()>;
 
     /// Apply the given log entry to the state machine.
@@ -139,18 +153,19 @@ where
     /// specific transaction is being started, or perhaps committed. This may be where a key/value
     /// is being stored. This may be where an entry is being appended to an immutable log.
     ///
-    /// The behavior here is application specific, but errors should never be returned unless the
-    /// error represents an actual failure to apply the entry. An error returned here will cause
-    /// the Raft node to shutdown in order to preserve the safety of the data and avoid corruption.
-    /// If instead some application specific error needs to be returned to the client, those
-    /// variants must be encapsulated in the type `R`, which may have application specific success
-    /// and error variants encoded in the type, perhaps using an inner `Result` type.
+    /// Error handling for this method is note worthy. If an error is returned from a call to this
+    /// method, the error will be inspected, and if the error is an instance of `AppError`, then
+    /// the error will propagate back to the `Raft.client_write` call point. If the error is of
+    /// any other type, then Raft will go into shutdown in order to preserve the safety of the
+    /// data and avoid corruption.
     async fn apply_entry_to_state_machine(&self, index: &u64, data: &D) -> Result<R>;
 
     /// Apply the given payload of entries to the state machine, as part of replication.
     ///
     /// The Raft protocol guarantees that only logs which have been _committed_, that is, logs which
     /// have been replicated to a majority of the cluster, will be applied to the state machine.
+    ///
+    /// Errors returned from this method will cause Raft to go into shutdown.
     async fn replicate_to_state_machine(&self, entries: &[(&u64, &D)]) -> Result<()>;
 
     /// Perform log compaction, returning a handle to the generated snapshot.
@@ -161,6 +176,8 @@ where
     /// storage implementation should export/checkpoint/snapshot its state machine, and then use
     /// the value of that export's last applied log as the metadata indicating the breadth of the
     /// log covered by the snapshot.
+    ///
+    /// Errors returned from this method will be logged and retried.
     async fn do_log_compaction(&self) -> Result<CurrentSnapshotData<Self::Snapshot>>;
 
     /// Create a new blank snapshot, returning a writable handle to the snapshot object along with
@@ -169,6 +186,8 @@ where
     /// ### implementation guide
     /// See the [storage chapter of the guide](https://async-raft.github.io/async-raft/storage.html)
     /// for details on log compaction / snapshotting.
+    ///
+    /// Errors returned from this method will cause Raft to go into shutdown.
     async fn create_snapshot(&self) -> Result<(String, Box<Self::Snapshot>)>;
 
     /// Finalize the installation of a snapshot which has finished streaming from the cluster leader.
@@ -187,6 +206,8 @@ where
     /// By the time ownership of the snapshot object is returned here, its
     /// `AsyncWriteExt.shutdown()` method will have been called, so no additional writes should be
     /// made to the snapshot.
+    ///
+    /// Errors returned from this method will cause Raft to go into shutdown.
     async fn finalize_snapshot_installation(
         &self, index: u64, term: u64, delete_through: Option<u64>, id: String, snapshot: Box<Self::Snapshot>,
     ) -> Result<()>;
@@ -202,5 +223,7 @@ where
     ///
     /// A proper snapshot implementation will store the term, index and membership config as part
     /// of the snapshot, which should be decoded for creating this method's response data.
+    ///
+    /// Errors returned from this method will cause Raft to go into shutdown.
     async fn get_current_snapshot(&self) -> Result<Option<CurrentSnapshotData<Self::Snapshot>>>;
 }


### PR DESCRIPTION
This is a farily large changeset, and is also a breaking change.
This introduces an `AppError` type (which actually existed in older
versions of this crate). This allows for the Raft system to
differentiate between fatal storage errors which should cause the system
to shutdown vs errors which should be propagated back to the client for
application specific error handling.

Overall, this constitutes a nice improvement to the RaftStorage
interface, as a flat result type may be used for propagating errors. No
result nesting required.

### todo
- [ ] add tests to ensure AppErrors are handled as expected from the storage layer.
- [ ] update guide.