### PR TITLE
Update Tokio to 1.0

### DIFF
--- a/async-raft/Cargo.toml
+++ b/async-raft/Cargo.toml
@@ -15,14 +15,14 @@ readme = "../README.md"
 [dependencies]
 anyhow = "1.0.32"
 async-trait = "0.1.36"
-bytes = "0.5"
+bytes = "1.0"
 derive_more = { version="0.99.9", default-features=false, features=["from"] }
 futures = "0.3"
 log = "0.4"
 rand = "0.7"
 serde = { version="1", features=["derive"] }
 thiserror = "1.0.20"
-tokio = { version="0.2", default-features=false, features=["fs", "io-util", "macros", "rt-core", "rt-threaded", "stream", "sync", "time"] }
+tokio = { version="1.0", default-features=false, features=["fs", "io-util", "macros", "rt", "rt-multi-thread", "sync", "time"] }
 tracing = "0.1"
 tracing-futures = "0.2.4"
 

--- a/async-raft/src/core/client.rs
+++ b/async-raft/src/core/client.rs
@@ -2,8 +2,7 @@ use std::sync::Arc;
 
 use anyhow::anyhow;
 use futures::future::TryFutureExt;
-use futures::stream::FuturesUnordered;
-use tokio::stream::StreamExt;
+use futures::stream::{FuturesUnordered, StreamExt};
 use tokio::sync::oneshot;
 use tokio::time::{timeout, Duration};
 

--- a/async-raft/src/core/vote.rs
+++ b/async-raft/src/core/vote.rs
@@ -143,7 +143,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         let (tx, rx) = mpsc::channel(all_members.len());
         for member in all_members.into_iter().filter(|member| member != &self.core.id) {
             let rpc = VoteRequest::new(self.core.current_term, self.core.id, self.core.last_log_index, self.core.last_log_term);
-            let (network, mut tx_inner) = (self.core.network.clone(), tx.clone());
+            let (network, tx_inner) = (self.core.network.clone(), tx.clone());
             let _ = tokio::spawn(
                 async move {
                     match network.vote(member, rpc).await {

--- a/async-raft/tests/client_reads.rs
+++ b/async-raft/tests/client_reads.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use async_raft::Config;
-use tokio::time::delay_for;
+use tokio::time::sleep;
 
 use fixtures::RaftRouter;
 
@@ -18,7 +18,7 @@ use fixtures::RaftRouter;
 /// - call the client_read interface on the followers, and assert failure.
 ///
 /// RUST_LOG=async_raft,memstore,client_reads=trace cargo test -p async-raft --test client_reads
-#[tokio::test(core_threads = 4)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn client_reads() -> Result<()> {
     fixtures::init_tracing();
 
@@ -30,13 +30,13 @@ async fn client_reads() -> Result<()> {
     router.new_raft_node(2).await;
 
     // Assert all nodes are in non-voter state & have no entries.
-    delay_for(Duration::from_secs(10)).await;
+    sleep(Duration::from_secs(10)).await;
     router.assert_pristine_cluster().await;
 
     // Initialize the cluster, then assert that a stable cluster was formed & held.
     tracing::info!("--- initializing cluster");
     router.initialize_from_single_node(0).await?;
-    delay_for(Duration::from_secs(10)).await;
+    sleep(Duration::from_secs(10)).await;
     router.assert_stable_cluster(Some(1), Some(1)).await;
 
     // Get the ID of the leader, and assert that client_read succeeds.

--- a/async-raft/tests/client_writes.rs
+++ b/async-raft/tests/client_writes.rs
@@ -8,7 +8,7 @@ use async_raft::raft::MembershipConfig;
 use async_raft::Config;
 use futures::prelude::*;
 use maplit::hashset;
-use tokio::time::delay_for;
+use tokio::time::sleep;
 
 use fixtures::RaftRouter;
 
@@ -21,7 +21,7 @@ use fixtures::RaftRouter;
 /// - assert that the cluster stayed stable and has all of the expected data.
 ///
 /// RUST_LOG=async_raft,memstore,client_writes=trace cargo test -p async-raft --test client_writes
-#[tokio::test(core_threads = 4)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn client_writes() -> Result<()> {
     fixtures::init_tracing();
 
@@ -33,13 +33,13 @@ async fn client_writes() -> Result<()> {
     router.new_raft_node(2).await;
 
     // Assert all nodes are in non-voter state & have no entries.
-    delay_for(Duration::from_secs(10)).await;
+    sleep(Duration::from_secs(10)).await;
     router.assert_pristine_cluster().await;
 
     // Initialize the cluster, then assert that a stable cluster was formed & held.
     tracing::info!("--- initializing cluster");
     router.initialize_from_single_node(0).await?;
-    delay_for(Duration::from_secs(10)).await;
+    sleep(Duration::from_secs(10)).await;
     router.assert_stable_cluster(Some(1), Some(1)).await;
 
     // Write a bunch of data and assert that the cluster stayes stable.
@@ -52,7 +52,7 @@ async fn client_writes() -> Result<()> {
     clients.push(router.client_request_many(leader, "4", 1000));
     clients.push(router.client_request_many(leader, "5", 1000));
     while clients.next().await.is_some() {}
-    delay_for(Duration::from_secs(5)).await; // Ensure enough time is given for replication (this is WAY more than enough).
+    sleep(Duration::from_secs(5)).await; // Ensure enough time is given for replication (this is WAY more than enough).
     router.assert_stable_cluster(Some(1), Some(6001)).await; // The extra 1 is from the leader's initial commit entry.
     router
         .assert_storage_state(

--- a/async-raft/tests/current_leader.rs
+++ b/async-raft/tests/current_leader.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use async_raft::Config;
-use tokio::time::delay_for;
+use tokio::time::sleep;
 
 use fixtures::RaftRouter;
 
@@ -17,7 +17,7 @@ use fixtures::RaftRouter;
 /// - call the current_leader interface on the all nodes, and assert success.
 ///
 /// RUST_LOG=async_raft,memstore,client_reads=trace cargo test -p async-raft --test current_leader
-#[tokio::test(core_threads = 4)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn current_leader() -> Result<()> {
     fixtures::init_tracing();
 
@@ -29,16 +29,16 @@ async fn current_leader() -> Result<()> {
     router.new_raft_node(2).await;
 
     // Assert all nodes are in non-voter state & have no entries.
-    delay_for(Duration::from_secs(10)).await;
+    sleep(Duration::from_secs(10)).await;
     router.assert_pristine_cluster().await;
 
     // Initialize the cluster, then assert that a stable cluster was formed & held.
     tracing::info!("--- initializing cluster");
     router.initialize_from_single_node(0).await?;
-    delay_for(Duration::from_secs(10)).await;
+    sleep(Duration::from_secs(10)).await;
     router.assert_stable_cluster(Some(1), Some(1)).await;
 
-    // Get the ID of the leader, and assert that client_read succeeds.
+    // Get the ID of the leader, and assert that current_leader succeeds.
     let leader = router.leader().await.expect("leader not found");
     assert_eq!(leader, 0, "expected leader to be node 0, got {}", leader);
 

--- a/async-raft/tests/shutdown.rs
+++ b/async-raft/tests/shutdown.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use anyhow::{anyhow, Result};
 use async_raft::Config;
-use tokio::time::delay_for;
+use tokio::time::sleep;
 
 use fixtures::RaftRouter;
 
@@ -18,7 +18,7 @@ use fixtures::RaftRouter;
 ///   on each node, asserting that the shutdown routine succeeded.
 ///
 /// RUST_LOG=async_raft,memstore,shutdown=trace cargo test -p async-raft --test shutdown
-#[tokio::test(core_threads = 4)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn initialization() -> Result<()> {
     fixtures::init_tracing();
 
@@ -30,13 +30,13 @@ async fn initialization() -> Result<()> {
     router.new_raft_node(2).await;
 
     // Assert all nodes are in non-voter state & have no entries.
-    delay_for(Duration::from_secs(10)).await;
+    sleep(Duration::from_secs(10)).await;
     router.assert_pristine_cluster().await;
 
     // Initialize the cluster, then assert that a stable cluster was formed & held.
     tracing::info!("--- initializing cluster");
     router.initialize_from_single_node(0).await?;
-    delay_for(Duration::from_secs(10)).await;
+    sleep(Duration::from_secs(10)).await;
     router.assert_stable_cluster(Some(1), Some(1)).await;
 
     tracing::info!("--- performing node shutdowns");

--- a/async-raft/tests/singlenode.rs
+++ b/async-raft/tests/singlenode.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use async_raft::Config;
-use tokio::time::delay_for;
+use tokio::time::sleep;
 
 use fixtures::RaftRouter;
 
@@ -20,7 +20,7 @@ use fixtures::RaftRouter;
 /// - asserts that the leader was able to successfully commit its initial payload.
 ///
 /// RUST_LOG=async_raft,memstore,singlenode=trace cargo test -p async-raft --test singlenode
-#[tokio::test(core_threads = 4)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn singlenode() -> Result<()> {
     fixtures::init_tracing();
 
@@ -30,13 +30,13 @@ async fn singlenode() -> Result<()> {
     router.new_raft_node(0).await;
 
     // Assert all nodes are in non-voter state & have no entries.
-    delay_for(Duration::from_secs(10)).await;
+    sleep(Duration::from_secs(10)).await;
     router.assert_pristine_cluster().await;
 
     // Initialize the cluster, then assert that a stable cluster was formed & held.
     tracing::info!("--- initializing cluster");
     router.initialize_from_single_node(0).await?;
-    delay_for(Duration::from_secs(10)).await;
+    sleep(Duration::from_secs(10)).await;
     router.assert_stable_cluster(Some(1), Some(1)).await;
 
     // Write some data to the single node cluster.

--- a/memstore/Cargo.toml
+++ b/memstore/Cargo.toml
@@ -18,7 +18,7 @@ async-raft = { version="0.6.0-alpha.2", path="../async-raft" }
 serde = { version="1.0.114", features=["derive"] }
 serde_json = "1.0.57"
 thiserror = "1.0.20"
-tokio = { version="0.2.22", default-features=false, features=["sync"] }
+tokio = { version="1.0", default-features=false, features=["sync"] }
 tracing = "0.1.17"
 tracing-futures = "0.2.4"
 


### PR DESCRIPTION
~~Also use `futures::channel::{mpsc, oneshot}` instead of
`tokio::sync::{mpsc, oneshot}` for two reasons:~~

* ~~`try_recv()` was removed from `mpsc` types in Tokio.
  See https://github.com/tokio-rs/tokio/pull/3263~~
* ~~This would help us to make this library runtime agnostic in the future.~~