### PR TITLE
Update Clippy CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,14 +12,6 @@ jobs:
         with:
           toolchain: 1.45.2
           default: true
-          components: clippy
-
-      # clippy
-      - name: Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -p async-raft -- -D warnings
 
       # unit tests
       - name: Unit Tests
@@ -105,14 +97,6 @@ jobs:
         with:
           toolchain: 1.45.2
           default: true
-          components: clippy
-
-      # clippy
-      - name: Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -p memstore -- -D warnings
 
       # unit tests
       - name: Unit Tests
@@ -127,3 +111,21 @@ jobs:
         with:
           command: build
           args: -p memstore --release
+
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup | Checkout
+        uses: actions/checkout@v2
+      - name: Setup | Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+          components: clippy
+      - name: Clippy
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-targets -- -D warnings

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup | Toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.45.2
+          toolchain: stable
           default: true
 
       # unit tests
@@ -95,7 +95,7 @@ jobs:
       - name: Setup | Toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.45.2
+          toolchain: stable
           default: true
 
       # unit tests


### PR DESCRIPTION
- Use https://github.com/actions-rs/clippy-check action for better reporting.
- Run clippy with latest stable Rust instead of old version
- Run clippy against all targets including test cases
 
Example of clippy result: https://github.com/xu-cheng/async-raft/runs/1604064699