### PR TITLE
Update MemStore::get_log_entries

### DIFF
--- a/memstore/src/lib.rs
+++ b/memstore/src/lib.rs
@@ -199,7 +199,9 @@ impl RaftStorage<ClientRequest, ClientResponse> for MemStore {
             return Ok(vec![]);
         }
         let log = self.log.read().await;
-        Ok(log.range(start..stop).map(|(_, val)| val.clone()).collect())
+        (start..stop)
+            .map(|i| log.get(&i).cloned().ok_or_else(|| anyhow::anyhow!("log not found")))
+            .collect()
     }
 
     #[tracing::instrument(level = "trace", skip(self))]


### PR DESCRIPTION
The previous implementation will silently ignore the problem if the
requested log entry cannot be found.

Update it so it can raise error in this case to properly test the system.

See https://github.com/async-raft/async-raft/issues/98#issuecomment-754452622