### PR TITLE
fix: a NonVoter should stay as NonVoter instead of Follower after restart

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,11 @@ jobs:
         with:
           command: test
           args: -p async-raft --test initialization
+      - name: Integration Test | NonVoter restart
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: -p async-raft --test non_voter_restart
       - name: Integration Test | Client Reads
         uses: actions-rs/cargo@v1
         with:

--- a/async-raft/src/core/mod.rs
+++ b/async-raft/src/core/mod.rs
@@ -183,38 +183,25 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
             self.snapshot_index = snapshot.index;
         }
 
-        let has_log = self.last_log_index != u64::min_value();
-        let single = self.membership.members.len() == 1;
-        let is_candidate = self.membership.contains(&self.id);
-
-        self.target_state = match (has_log, single, is_candidate) {
-            // A restarted raft that already received some logs but was not yet added to a cluster.
-            // It should remain in NonVoter state, not Follower.
-            (true, true, false) => State::NonVoter,
-            (true, false, false) => State::NonVoter,
-
-            (false, true, false) => State::NonVoter,  // impossible: no logs but there are other members.
-            (false, false, false) => State::NonVoter, // impossible: no logs but there are other members.
-
-            // If this is the only configured member and there is live state, then this is
-            // a single-node cluster. Become leader.
-            (true, true, true) => State::Leader,
-
-            // The initial state when a raft is created from empty store.
-            (false, true, true) => State::NonVoter,
-
-            // Otherwise it is Follower.
-            (true, false, true) => State::Follower,
-
-            (false, false, true) => State::Follower, // impossible: no logs but there are other members.
-        };
-
-        if self.target_state == State::Follower {
-            // Here we use a 30 second overhead on the initial next_election_timeout. This is because we need
-            // to ensure that restarted nodes don't disrupt a stable cluster by timing out and driving up their
-            // term before network communication is established.
+        // Set initial state based on state recovered from disk.
+        let is_only_configured_member = self.membership.members.len() == 1 && self.membership.contains(&self.id);
+        // If this is the only configured member and there is live state, then this is
+        // a single-node cluster. Become leader.
+        if is_only_configured_member && self.last_log_index != u64::min_value() {
+            self.target_state = State::Leader;
+        }
+        // Else if there are other members, that can only mean that state was recovered. Become follower.
+        // Here we use a 30 second overhead on the initial next_election_timeout. This is because we need
+        // to ensure that restarted nodes don't disrupt a stable cluster by timing out and driving up their
+        // term before network communication is established.
+        else if !is_only_configured_member {
+            self.set_target_state(State::Follower); // Will set to NonVoter if not a configured member.
             let inst = Instant::now() + Duration::from_secs(30) + Duration::from_millis(self.config.new_rand_election_timeout());
             self.next_election_timeout = Some(inst);
+        }
+        // Else, for any other condition, stay non-voter.
+        else {
+            self.target_state = State::NonVoter;
         }
 
         // This is central loop of the system. The Raft core assumes a few different roles based

--- a/async-raft/src/core/mod.rs
+++ b/async-raft/src/core/mod.rs
@@ -194,8 +194,8 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
         // Here we use a 30 second overhead on the initial next_election_timeout. This is because we need
         // to ensure that restarted nodes don't disrupt a stable cluster by timing out and driving up their
         // term before network communication is established.
-        else if !is_only_configured_member {
-            self.set_target_state(State::Follower); // Will set to NonVoter if not a configured member.
+        else if !is_only_configured_member && self.membership.contains(&self.id) {
+            self.target_state = State::Follower;
             let inst = Instant::now() + Duration::from_secs(30) + Duration::from_millis(self.config.new_rand_election_timeout());
             self.next_election_timeout = Some(inst);
         }

--- a/async-raft/src/core/mod.rs
+++ b/async-raft/src/core/mod.rs
@@ -183,25 +183,38 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
             self.snapshot_index = snapshot.index;
         }
 
-        // Set initial state based on state recovered from disk.
-        let is_only_configured_member = self.membership.members.len() == 1 && self.membership.contains(&self.id);
-        // If this is the only configured member and there is live state, then this is
-        // a single-node cluster. Become leader.
-        if is_only_configured_member && self.last_log_index != u64::min_value() {
-            self.target_state = State::Leader;
-        }
-        // Else if there are other members, that can only mean that state was recovered. Become follower.
-        // Here we use a 30 second overhead on the initial next_election_timeout. This is because we need
-        // to ensure that restarted nodes don't disrupt a stable cluster by timing out and driving up their
-        // term before network communication is established.
-        else if !is_only_configured_member {
-            self.target_state = State::Follower;
+        let has_log = self.last_log_index != u64::min_value();
+        let single = self.membership.members.len() == 1;
+        let is_candidate = self.membership.contains(&self.id);
+
+        self.target_state = match (has_log, single, is_candidate) {
+            // A restarted raft that already received some logs but was not yet added to a cluster.
+            // It should remain in NonVoter state, not Follower.
+            (true, true, false) => State::NonVoter,
+            (true, false, false) => State::NonVoter,
+
+            (false, true, false) => State::NonVoter,  // impossible: no logs but there are other members.
+            (false, false, false) => State::NonVoter, // impossible: no logs but there are other members.
+
+            // If this is the only configured member and there is live state, then this is
+            // a single-node cluster. Become leader.
+            (true, true, true) => State::Leader,
+
+            // The initial state when a raft is created from empty store.
+            (false, true, true) => State::NonVoter,
+
+            // Otherwise it is Follower.
+            (true, false, true) => State::Follower,
+
+            (false, false, true) => State::Follower, // impossible: no logs but there are other members.
+        };
+
+        if self.target_state == State::Follower {
+            // Here we use a 30 second overhead on the initial next_election_timeout. This is because we need
+            // to ensure that restarted nodes don't disrupt a stable cluster by timing out and driving up their
+            // term before network communication is established.
             let inst = Instant::now() + Duration::from_secs(30) + Duration::from_millis(self.config.new_rand_election_timeout());
             self.next_election_timeout = Some(inst);
-        }
-        // Else, for any other condition, stay non-voter.
-        else {
-            self.target_state = State::NonVoter;
         }
 
         // This is central loop of the system. The Raft core assumes a few different roles based

--- a/async-raft/tests/fixtures/mod.rs
+++ b/async-raft/tests/fixtures/mod.rs
@@ -87,6 +87,18 @@ impl RaftRouter {
         Ok(())
     }
 
+    /// Initialize cluster with specified node ids.
+    pub async fn initialize_with(&self, node: NodeId, members: HashSet<NodeId>) -> Result<()> {
+        tracing::info!({ node }, "initializing cluster from single node");
+        let rt = self.routing_table.read().await;
+        rt.get(&node)
+            .ok_or_else(|| anyhow!("node {} not found in routing table", node))?
+            .0
+            .initialize(members.clone())
+            .await?;
+        Ok(())
+    }
+
     /// Isolate the network of the specified node.
     #[tracing::instrument(level = "debug", skip(self))]
     pub async fn isolate_node(&self, id: NodeId) {

--- a/async-raft/tests/non_voter_restart.rs
+++ b/async-raft/tests/non_voter_restart.rs
@@ -1,0 +1,78 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use maplit::hashset;
+use tokio::time::sleep;
+
+use async_raft::{Config, NodeId, Raft, RaftStorage, State};
+use async_raft::raft::MembershipConfig;
+use async_raft::storage::HardState;
+use fixtures::RaftRouter;
+use memstore::MemStore;
+
+use crate::fixtures::MemRaft;
+
+mod fixtures;
+
+/// Cluster non_voter_restart test.
+///
+/// What does this test do?
+///
+/// - brings 2 nodes online: one leader and one non-voter.
+/// - write one log to the leader.
+/// - asserts that the leader was able to successfully commit its initial payload and that the
+///   non-voter has successfully replicated the payload.
+/// - shutdown all and retstart the non-voter node.
+/// - asserts the non-voter stays in non-vtoer state.
+///
+/// RUST_LOG=async_raft,memstore,non_voter_restart=trace cargo test -p async-raft --test
+/// non_voter_restart
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn non_voter_restart() -> Result<()> {
+    fixtures::init_tracing();
+
+    // Setup test dependencies.
+    let config = Arc::new(Config::build("test".into()).validate().expect("failed to build Raft config"));
+    let router = Arc::new(RaftRouter::new(config.clone()));
+
+    router.new_raft_node(0).await;
+    router.new_raft_node(1).await;
+
+    // Assert all nodes are in non-voter state & have no entries.
+    sleep(Duration::from_secs(2)).await;
+    router.assert_pristine_cluster().await;
+
+    tracing::info!("--- initializing single node cluster");
+
+    router.initialize_with(0, hashset![0]).await?;
+    router.add_non_voter(0, 1).await?;
+    router.client_request(0, "foo", 1).await;
+    sleep(Duration::from_secs(2)).await;
+
+    let (node0, _sto0) = router.remove_node(0).await.unwrap();
+    assert_node_state(0, &node0, 1, 2, State::Leader);
+    node0.shutdown().await?;
+
+    let (node1, sto1) = router.remove_node(1).await.unwrap();
+    assert_node_state(0, &node1, 1, 2, State::NonVoter);
+    node1.shutdown().await?;
+
+    // restart node-1, assert the state as expected.
+    let restarted = Raft::new(1, config.clone(), router.clone(), sto1);
+    sleep(Duration::from_secs(2)).await;
+    assert_node_state(1, &restarted, 1, 2, State::NonVoter);
+
+    Ok(())
+}
+
+fn assert_node_state(id: NodeId, node: &MemRaft, expected_term: u64, expected_log: u64, state: State) {
+    let m = node.metrics().borrow().clone();
+    tracing::info!("node {} metrics: {:?}", id, m);
+
+    assert_eq!(expected_term, m.current_term, "node {} term", id);
+    assert_eq!(expected_log, m.last_log_index, "node {} last_log_index", id);
+    assert_eq!(expected_log, m.last_applied, "node {} last_log_index", id);
+    assert_eq!(state, m.state, "node {} state", id);
+}

--- a/async-raft/tests/non_voter_restart.rs
+++ b/async-raft/tests/non_voter_restart.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -6,11 +5,8 @@ use anyhow::Result;
 use maplit::hashset;
 use tokio::time::sleep;
 
-use async_raft::{Config, NodeId, Raft, RaftStorage, State};
-use async_raft::raft::MembershipConfig;
-use async_raft::storage::HardState;
+use async_raft::{Config, NodeId, Raft, State};
 use fixtures::RaftRouter;
-use memstore::MemStore;
 
 use crate::fixtures::MemRaft;
 
@@ -27,8 +23,7 @@ mod fixtures;
 /// - shutdown all and retstart the non-voter node.
 /// - asserts the non-voter stays in non-vtoer state.
 ///
-/// RUST_LOG=async_raft,memstore,non_voter_restart=trace cargo test -p async-raft --test
-/// non_voter_restart
+/// RUST_LOG=async_raft,memstore,non_voter_restart=trace cargo test -p async-raft --test non_voter_restart
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn non_voter_restart() -> Result<()> {
     fixtures::init_tracing();


### PR DESCRIPTION
# Summary

When restarting a NonVoter node with some log, the raft State initialization makes a NonVoter node a Follower node:
https://github.com/async-raft/async-raft/blob/master/async-raft/src/core/mod.rs#L187-L223

Which lets a NonVoter has a chance to elect itself.

# Reproduce

- Start node 0 and node 1 with an empty store.
- Initialize node 0 with a cluster with only itself in it.
- Call `add_non_voter(1)` on node 0 to let it forward logs to node 1.
- Write a log and commit it. Now both node 0 and node 1 have the written log.
- Shut down both. Then restart node 1(the NonVoter) with the populated store.
- Then node 1 becomes a Follower.

Detailed steps are in the test file `non_voter_restart.rs`.

# Solution

When initializing a raft node, make it a NonVoter when there is log in store and it is not a member.